### PR TITLE
Fixing backoff calculation & adding comments

### DIFF
--- a/crates/anemo/src/endpoint.rs
+++ b/crates/anemo/src/endpoint.rs
@@ -10,6 +10,10 @@ use std::{
 };
 use tracing::trace;
 
+/// A QUIC endpoint.
+///
+/// An endpoint corresponds to a single UDP socket, may host many connections, and may act as both
+/// client and server for different connections.
 #[derive(Debug)]
 pub(crate) struct Endpoint {
     inner: quinn::Endpoint,

--- a/crates/anemo/src/network/request_handler.rs
+++ b/crates/anemo/src/network/request_handler.rs
@@ -13,6 +13,10 @@ use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 use tower::{util::BoxCloneService, ServiceExt};
 use tracing::{debug, trace};
 
+/// Manages incoming requests from a peer.
+///
+/// Currently only bi-directional streams are supported. Whenever a new request (stream) is
+/// received a new task is spawn to handle it.
 pub(crate) struct InboundRequestHandler {
     connection: Connection,
 
@@ -93,6 +97,8 @@ impl InboundRequestHandler {
     }
 }
 
+/// Handles a single incoming request from a peer. It receives the request, forwards it
+/// to the service for processing and the sends back to peer the response.
 struct BiStreamRequestHandler {
     connection: Connection,
     service: BoxCloneService<Request<Bytes>, Response<Bytes>, Infallible>,


### PR DESCRIPTION
This PR is:
* fixing the backoff calculation logic in the `DialBackoffState`
* adding more debug statements and some comments in codebase

While looking in the codebase and familiarise my self I took the opportunity to add some extra debug statements which I believe would be useful and also some comments in the codebase.

Also, looking on how `DialBackoffState` and assuming I understand the intended behaviour, I am changing a `max` comparison to `min` to ensure that the maximum backoff property will be respected.

The current behaviour will always use the maximum backoff - `60 seconds` in our current setup - even after first attempt and will keep increasing once the `attempts * back_off_step` becomes greater , which will push us effectively to infinity and make retries super rare.