### PR TITLE
[memory] Ensure that SendStreams are reset even if the future is dropped

### DIFF
--- a/crates/anemo/src/network/peer.rs
+++ b/crates/anemo/src/network/peer.rs
@@ -5,8 +5,22 @@ use super::{
 use crate::{connection::Connection, PeerId, Request, Response, Result};
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use tokio_util::codec::{FramedRead, FramedWrite};
+use quinn::{RecvStream, SendStream};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 use tower::{Layer, Service, ServiceExt};
+
+// A private structure to hold streams and ensure that if it is dropped
+// the send side is reset to free retransmit buffers.
+struct StreamPair {
+    pub send_stream: FramedWrite<SendStream, LengthDelimitedCodec>,
+    pub recv_stream: FramedRead<RecvStream, LengthDelimitedCodec>,
+}
+
+impl Drop for StreamPair {
+    fn drop(&mut self) {
+        let _ = self.send_stream.get_mut().reset(0u8.into());
+    }
+}
 
 /// Handle to a connection with a remote Peer.
 #[derive(Clone)]
@@ -36,21 +50,26 @@ impl Peer {
 
     async fn do_rpc(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
         let (send_stream, recv_stream) = self.connection.open_bi().await?;
-        let mut send_stream = FramedWrite::new(send_stream, network_message_frame_codec());
-        let mut recv_stream = FramedRead::new(recv_stream, network_message_frame_codec());
+        let send_stream = FramedWrite::new(send_stream, network_message_frame_codec());
+        let recv_stream = FramedRead::new(recv_stream, network_message_frame_codec());
+
+        let mut stream_pair = StreamPair {
+            send_stream,
+            recv_stream,
+        };
 
         //
         // Write Request
         //
 
-        write_request(&mut send_stream, request).await?;
-        send_stream.get_mut().finish().await?;
+        write_request(&mut stream_pair.send_stream, request).await?;
+        stream_pair.send_stream.get_mut().finish().await?;
 
         //
         // Read Response
         //
 
-        let mut response = read_response(&mut recv_stream).await?;
+        let mut response = read_response(&mut stream_pair.recv_stream).await?;
 
         // Set the PeerId of this peer
         response.extensions_mut().insert(self.peer_id());

--- a/crates/anemo/src/network/request_handler.rs
+++ b/crates/anemo/src/network/request_handler.rs
@@ -141,7 +141,7 @@ impl BiStreamRequestHandler {
         // We also watch the send_stream and see if it has been prematurely terminated by the
         // remote side indicating that this RPC was canceled.
         let response = {
-            let handler = self.service.oneshot(request);
+            let handler = self.service.clone().oneshot(request);
             let stopped = self.send_stream.get_mut().stopped();
             tokio::select! {
                 response = handler => response.expect("Infallible"),
@@ -157,5 +157,11 @@ impl BiStreamRequestHandler {
         self.send_stream.get_mut().finish().await?;
 
         Ok(())
+    }
+}
+
+impl Drop for BiStreamRequestHandler {
+    fn drop(&mut self) {
+        let _ = self.send_stream.get_mut().reset(0u8.into());
     }
 }


### PR DESCRIPTION
It turns out that the quinn SendStream will buffer and try to resend a message that has been scheduled for sending. But we want to make sure that if the future that drives the sending is dropped before it finishes, then we can stop re-sending and free memory.