### PR TITLE
[refactor] add timeout during shutdown

### DIFF
--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -116,7 +116,7 @@ pub struct Config {
     /// Set a timeout, in milliseconds, until the peers are notified when network
     /// is shutting down
     ///
-    /// If unspecified, there will be no limit
+    /// If unspecified, then this will default to 1 minute (60 * 1_000 ms)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shutdown_idle_timeout_ms: Option<u64>,
 }
@@ -238,9 +238,11 @@ impl Config {
     }
 
     pub(crate) fn shutdown_idle_timeout(&self) -> Duration {
+        const DEFAULT_SHUTDOWN_IDLE_TIMEOUT_MS: u64 = 60_000; // 1 minute
+
         self.shutdown_idle_timeout_ms
             .map(Duration::from_millis)
-            .unwrap_or(Duration::MAX)
+            .unwrap_or(Duration::from_millis(DEFAULT_SHUTDOWN_IDLE_TIMEOUT_MS))
     }
 }
 

--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -112,6 +112,13 @@ pub struct Config {
     /// In unspecified, no default timeout will be configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outbound_request_timeout_ms: Option<u64>,
+
+    /// Set a timeout, in milliseconds, until the peers are notified when network
+    /// is shutting down
+    ///
+    /// In unspecified, this will default to `1,000` milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shutdown_idle_timeout_ms: Option<u64>,
 }
 
 /// Configuration for the underlying QUIC transport.
@@ -228,6 +235,10 @@ impl Config {
 
     pub(crate) fn outbound_request_timeout(&self) -> Option<Duration> {
         self.outbound_request_timeout_ms.map(Duration::from_millis)
+    }
+
+    pub(crate) fn shutdown_idle_timeout(&self) -> Option<Duration> {
+        self.shutdown_idle_timeout_ms.map(Duration::from_millis)
     }
 }
 

--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -116,7 +116,7 @@ pub struct Config {
     /// Set a timeout, in milliseconds, until the peers are notified when network
     /// is shutting down
     ///
-    /// In unspecified, this will default to `1,000` milliseconds.
+    /// If unspecified, there will be no limit
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shutdown_idle_timeout_ms: Option<u64>,
 }

--- a/crates/anemo/src/config.rs
+++ b/crates/anemo/src/config.rs
@@ -237,8 +237,10 @@ impl Config {
         self.outbound_request_timeout_ms.map(Duration::from_millis)
     }
 
-    pub(crate) fn shutdown_idle_timeout(&self) -> Option<Duration> {
-        self.shutdown_idle_timeout_ms.map(Duration::from_millis)
+    pub(crate) fn shutdown_idle_timeout(&self) -> Duration {
+        self.shutdown_idle_timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::MAX)
     }
 }
 

--- a/crates/anemo/src/endpoint.rs
+++ b/crates/anemo/src/endpoint.rs
@@ -107,13 +107,11 @@ impl Endpoint {
     /// Does not proactively close existing connections or cause incoming connections to be
     /// rejected. Consider calling [`close()`] if that is desired.
     ///
-    /// An optional max_timeout property can be provided to ensure that the method
+    /// A max_timeout property should be provided to ensure that the method
     /// will only wait for the designated duration and exit if the limit has been reached.
     ///
     /// [`close()`]: Endpoint::close
-    pub async fn wait_idle(&self, max_timeout: Option<Duration>) {
-        let max_timeout = max_timeout.unwrap_or(Duration::MAX);
-
+    pub async fn wait_idle(&self, max_timeout: Duration) {
         if timeout(max_timeout, self.inner.wait_idle()).await.is_err() {
             warn!(
                 "Max timeout reached {}s while waiting for connections clean shutdown",

--- a/crates/anemo/src/endpoint.rs
+++ b/crates/anemo/src/endpoint.rs
@@ -2,6 +2,7 @@ use crate::{
     config::EndpointConfig, connection::Connection, types::Address, ConnectionOrigin, PeerId,
     Result,
 };
+use std::time::Duration;
 use std::{
     future::Future,
     net::SocketAddr,
@@ -10,7 +11,8 @@ use std::{
     task::{Context, Poll},
 };
 use tap::Pipe;
-use tracing::trace;
+use tokio::time::timeout;
+use tracing::{trace, warn};
 
 /// A QUIC endpoint.
 ///
@@ -105,9 +107,19 @@ impl Endpoint {
     /// Does not proactively close existing connections or cause incoming connections to be
     /// rejected. Consider calling [`close()`] if that is desired.
     ///
+    /// An optional max_timeout property can be provided to ensure that the method
+    /// will only wait for the designated duration and exit if the limit has been reached.
+    ///
     /// [`close()`]: Endpoint::close
-    pub async fn wait_idle(&self) {
-        self.inner.wait_idle().await;
+    pub async fn wait_idle(&self, max_timeout: Option<Duration>) {
+        let max_timeout = max_timeout.unwrap_or(Duration::MAX);
+
+        if timeout(max_timeout, self.inner.wait_idle()).await.is_err() {
+            warn!(
+                "Max timeout reached {}s while waiting for connections clean shutdown",
+                max_timeout.as_secs_f64()
+            );
+        }
     }
 
     /// Switch to a new UDP socket

--- a/crates/anemo/src/network/connection_manager.rs
+++ b/crates/anemo/src/network/connection_manager.rs
@@ -793,13 +793,8 @@ mod tests {
         let address = socket.local_addr().unwrap();
         let config = crate::config::EndpointConfig::random("test");
         let endpoint = Arc::new(Endpoint::new(config, socket).unwrap());
-        let manager_config = Config {
-            shutdown_idle_timeout_ms: Some(10_000),
-            ..Default::default()
-        };
-
         let (connection_manager, sender) = ConnectionManager::new(
-            Arc::new(manager_config),
+            Default::default(),
             endpoint,
             ActivePeers::new(1),
             Default::default(),


### PR DESCRIPTION
I preferred to use a `config` parameter to enable setting the timeout duration instead of directing passing as parameter to the network `shutdown` method, as the later would probably be more confusing to the user of the method - as we timeout only on a portion of the overall shutdown process and not on the shutdown as a whole